### PR TITLE
Support webgl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,12 @@ wasm-opt = ["-Oz", "--enable-mutable-globals"]
 version = "0.3.4"
 features = [
     'CanvasRenderingContext2d',
+    'WebGlBuffer',
+    'WebGlRenderingContext',
+    'WebGlProgram',
+    'WebGlShader',
+    'WebGlUniformLocation',
+    'WebGlTexture',
     'Element',
     'HtmlElement',
     'HtmlCanvasElement',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ wasm-bindgen = "0.2.67"
 js-sys = ""
 console_error_panic_hook = "0.1.6"
 libm = "0.1.4"
+cgmath = "0.18.0"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/js/index.js
+++ b/js/index.js
@@ -10,7 +10,16 @@ async function run(module) {
   let canvas;
   let canvasSize;
 
+  let useWebGL = true;
   let [width, height] = [200, 200];
+  let pendingRestart = false;
+
+  function setUseWebGL(value){
+    useWebGL = value;
+    [pixelScale, canvasScale] = useWebGL ? [1., 4] : [4., 1.];
+    resizeCanvas();
+    pendingRestart = true;
+  }
 
   function resizeCanvas(){
     if(canvas)
@@ -26,9 +35,8 @@ async function run(module) {
       params.mousePos = [event.offsetX / canvasScale / pixelScale, event.offsetY / canvasScale / pixelScale];
     });
   }
-  resizeCanvas();
 
-  let useWebGL = false;
+  setUseWebGL(true);
 
   let params = {
     deltaTime: 1.0,
@@ -107,13 +115,7 @@ async function run(module) {
     radioButton.addEventListener("click", update);
     return radioButton;
   }
-  let pendingRestart = false;
-  const useWebGLCheck = checkboxInit("useWebGL", value => {
-    useWebGL = value;
-    [pixelScale, canvasScale] = useWebGL ? [1., 4] : [4., 1.];
-    resizeCanvas();
-    pendingRestart = true;
-  });
+  const useWebGLCheck = checkboxInit("useWebGL", setUseWebGL);
   const deltaTimeSlider = sliderInit("deltaTime", "deltaTimeLabel", value => params.deltaTime = value);
   const skipFramesSlider = sliderInit("skipFrames", "skipFramesLabel", value => params.skipFrames = value);
   const fSlider = sliderInit("visc", "viscLabel", value => params.visc = value, true);

--- a/js/index.js
+++ b/js/index.js
@@ -121,7 +121,7 @@ async function run(module) {
     resetParticles = true;
   })
 
-  const pixelScale = 2.;
+  const pixelScale = 4.;
 
   canvas.addEventListener("mousemove", (event) => {
       params.mousePos = [event.offsetX / canvasScale / pixelScale, event.offsetY / canvasScale / pixelScale];

--- a/js/index.js
+++ b/js/index.js
@@ -3,7 +3,7 @@ import("../pkg/index.js").catch(console.error).then(run);
 async function run(module) {
   const { cfd } = module;
 
-  const canvasScale = 2.;
+  const canvasScale = 1.;
   const canvas = document.getElementById('canvas');
   const canvasSize = canvas.getBoundingClientRect();
   canvas.style.width = canvasSize.width * canvasScale + "px";
@@ -121,17 +121,19 @@ async function run(module) {
     resetParticles = true;
   })
 
+  const pixelScale = 2.;
+
   canvas.addEventListener("mousemove", (event) => {
-      params.mousePos = [event.offsetX / canvasScale, event.offsetY / canvasScale];
+      params.mousePos = [event.offsetX / canvasScale / pixelScale, event.offsetY / canvasScale / pixelScale];
   })
 
-  var label = document.getElementById('label');
+  const label = document.getElementById('label');
 
   function startAnimation(){
     console.time('Rendering in Rust')
     try{
     //   deserialize_string(yamlText, canvasSize.width, canvasSize.height,
-        cfd(canvasSize.width, canvasSize.height, ctx,
+        cfd(canvasSize.width / pixelScale, canvasSize.height / pixelScale, ctx,
             (particles) => {
               // ctx.lineWidth = 1.;
               // ctx.strokeStyle = "#ffffff";

--- a/js/index.js
+++ b/js/index.js
@@ -35,7 +35,7 @@ async function run(module) {
     projIter: 10,
     mousePos: undefined,
   };
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext('webgl');
 
   const animateCheckbox = document.getElementById("animate");
   const sliderUpdater = [];
@@ -132,9 +132,17 @@ async function run(module) {
     try{
     //   deserialize_string(yamlText, canvasSize.width, canvasSize.height,
         cfd(canvasSize.width, canvasSize.height, ctx,
-            (average) => {
-                // ctx.putImageData(data, 0, 0);
-                // label.innerHTML = average;
+            (particles) => {
+              ctx.lineWidth = 1.;
+              ctx.strokeStyle = "#ffffff";
+              ctx.beginPath();
+              for(let i = 0; i < particles.length / 2; i++){
+                ctx.moveTo(particles[i * 2], particles[i * 2 + 1]);
+                ctx.lineTo(particles[i * 2], particles[i * 2 + 1] + 1);
+              }
+              ctx.stroke();
+              // ctx.putImageData(data, 0, 0);
+                label.innerHTML = particles.buffer;
                 const animateCheckbox = document.getElementById("animate");
                 const ret = {
                     terminate: !animateCheckbox.checked,

--- a/js/index.js
+++ b/js/index.js
@@ -133,14 +133,14 @@ async function run(module) {
     //   deserialize_string(yamlText, canvasSize.width, canvasSize.height,
         cfd(canvasSize.width, canvasSize.height, ctx,
             (particles) => {
-              ctx.lineWidth = 1.;
-              ctx.strokeStyle = "#ffffff";
-              ctx.beginPath();
-              for(let i = 0; i < particles.length / 2; i++){
-                ctx.moveTo(particles[i * 2], particles[i * 2 + 1]);
-                ctx.lineTo(particles[i * 2], particles[i * 2 + 1] + 1);
-              }
-              ctx.stroke();
+              // ctx.lineWidth = 1.;
+              // ctx.strokeStyle = "#ffffff";
+              // ctx.beginPath();
+              // for(let i = 0; i < particles.length / 2; i++){
+              //   ctx.moveTo(particles[i * 2], particles[i * 2 + 1]);
+              //   ctx.lineTo(particles[i * 2], particles[i * 2 + 1] + 1);
+              // }
+              // ctx.stroke();
               // ctx.putImageData(data, 0, 0);
                 label.innerHTML = particles.buffer;
                 const animateCheckbox = document.getElementById("animate");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -664,8 +664,7 @@ impl State {
 
             if 0 < self.params.particle_trails {
                 if use_webgl && self.assets.instanced_arrays_ext.is_some() {
-                    while self.params.particle_trails <= particle.history_buf.len() / 3 {
-                        particle.history_buf.remove(0);
+                    while self.params.particle_trails <= particle.history_buf.len() / 2 {
                         particle.history_buf.remove(0);
                         particle.history_buf.remove(0);
                     }
@@ -673,7 +672,6 @@ impl State {
                     particle.history_buf.extend_from_slice(&[
                         particle.position.0 as f32 / self.shape.0 as f32,
                         particle.position.1 as f32 / self.shape.1 as f32,
-                        1.,
                     ]);
                 } else {
                     while self.params.particle_trails <= particle.history.len() {
@@ -691,14 +689,13 @@ impl State {
                 self.particle_buf[idx * 3 + 2] = 1.;
                 idx += 1;
 
-                self.particle_buf[idx * 3..idx * 3 + particle.history_buf.len()].copy_from_slice(
-                    &particle.history_buf
-                );
-                let history_len = particle.history_buf.len() / 3;
+                let history_len = particle.history_buf.len() / 2;
                 for i in 0..history_len {
+                    self.particle_buf[(idx + i) * 3    ] = particle.history_buf[i * 2    ];
+                    self.particle_buf[(idx + i) * 3 + 1] = particle.history_buf[i * 2 + 1];
                     self.particle_buf[(idx + i) * 3 + 2] = i as f32 / history_len as f32;
                 }
-                idx += particle.history_buf.len() / 3;
+                idx += particle.history_buf.len() / 2;
             }
 
             // For some reason, updating particle.position after writing into particle_buf seems correct,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,7 +727,7 @@ impl State {
 
         enable_buffer(gl, &self.assets.rect_buffer, 2, shader.vertex_position);
         for particle in &self.particles {
-            let (x, y) = (particle.position.0 as isize, particle.position.1 as isize);
+            let (x, y) = (particle.position.0, particle.position.1);
             let translation = Matrix4::from_translation(
                 Vector3::new(x as f32 / self.shape.0 as f32, y as f32 / self.shape.1 as f32, 0.));
             gl.uniform_matrix4fv_with_f32_array(
@@ -948,7 +948,8 @@ impl State {
     }
 
     fn put_image_gl(&self, gl: &GL, data: &[u8]) -> Result<(), JsValue> {
-        gl.use_program(Some(&self.assets.rect_shader.as_ref().ok_or_else(|| JsValue::from_str("Could not find rect_shader"))?.program));
+        gl.use_program(Some(&self.assets.rect_shader.as_ref().ok_or_else(
+            || JsValue::from_str("Could not find rect_shader"))?.program));
 
         gl.active_texture(GL::TEXTURE0);
         gl.bind_texture(GL::TEXTURE_2D, self.assets.flow_tex.as_ref());
@@ -971,6 +972,10 @@ impl State {
         console_log!("Drawing {:?}", self.shape);
 
         self.draw_tex(gl)?;
+
+        if self.params.particles {
+            self.render_particles_gl(gl)?;
+        }
 
         Ok(())
     }
@@ -1047,8 +1052,6 @@ pub fn cfd(width: usize, height: usize, ctx: GL, callback: js_sys::Function) -> 
         state.put_image_gl(&ctx, &data)?;
         // ctx.put_image_data(&image_data, 0., 0.)?;
         // state.render_velocity_field(&ctx);
-
-        state.render_particles_gl(&ctx)?;
 
         let particle_vec = state.particles.iter()
         .fold(vec![], |mut acc, p| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ struct Particle {
 }
 
 fn new_particles(xor128: &mut Xor128, shape: Shape) -> Vec<Particle> {
-    (0..1000).map(|_| Particle {
+    (0..PARTICLE_COUNT).map(|_| Particle {
         position: ((xor128.nexti() as isize % shape.0) as f64, (xor128.nexti() as isize % shape.1) as f64),
         history: vec![],
         history_buf: vec![],
@@ -410,6 +410,7 @@ struct Params{
     boundary_x: BoundaryCondition,
 }
 
+const PARTICLE_COUNT: usize = 1000;
 const PARTICLE_SIZE: f32 = 0.75;
 const PARTICLE_MAX_TRAIL_LEN: usize = 10;
 
@@ -1160,7 +1161,7 @@ impl State {
         gl.bind_buffer(GL::ARRAY_BUFFER, self.assets.particle_buffer.as_ref());
         gl.buffer_data_with_i32(
             GL::ARRAY_BUFFER,
-            (self.particles.len() * 3 * std::mem::size_of::<f32>() * (1 + PARTICLE_MAX_TRAIL_LEN)) as i32,
+            (PARTICLE_COUNT * 3 * std::mem::size_of::<f32>() * (1 + PARTICLE_MAX_TRAIL_LEN)) as i32,
             GL::DYNAMIC_DRAW
         );
 

--- a/src/shader_bundle.rs
+++ b/src/shader_bundle.rs
@@ -8,7 +8,8 @@ pub struct ShaderBundle {
     pub transform_loc: Option<WebGlUniformLocation>,
     pub tex_transform_loc: Option<WebGlUniformLocation>,
     pub alpha_loc: Option<WebGlUniformLocation>,
-    pub position_loc: i32,
+    pub attrib_position_loc: i32,
+    pub attrib_alpha_loc: i32,
 }
 
 impl ShaderBundle {
@@ -26,6 +27,10 @@ impl ShaderBundle {
         let tex_coord_position = gl.get_attrib_location(&program, "vertexData") as u32;
         console_log!("vertex_position: {}", vertex_position);
         console_log!("tex_coord_position: {}", tex_coord_position);
+        let attrib_position_loc = gl.get_attrib_location(&program, "position");
+        console_log!("attrib_position_loc: {}", attrib_position_loc);
+        let attrib_alpha_loc = gl.get_attrib_location(&program, "alpha");
+        console_log!("attrib_alpha_loc: {}", attrib_alpha_loc);
         Self {
             vertex_position,
             tex_coord_position,
@@ -33,7 +38,8 @@ impl ShaderBundle {
             transform_loc: get_uniform("transform"),
             tex_transform_loc: get_uniform("texTransform"),
             alpha_loc: get_uniform("alpha"),
-            position_loc: gl.get_attrib_location(&program, "position"),
+            attrib_position_loc,
+            attrib_alpha_loc,
             // Program has to be later than others
             program,
         }

--- a/src/shader_bundle.rs
+++ b/src/shader_bundle.rs
@@ -8,6 +8,7 @@ pub struct ShaderBundle {
     pub transform_loc: Option<WebGlUniformLocation>,
     pub tex_transform_loc: Option<WebGlUniformLocation>,
     pub alpha_loc: Option<WebGlUniformLocation>,
+    pub matrix_loc: i32,
 }
 
 impl ShaderBundle {
@@ -32,6 +33,7 @@ impl ShaderBundle {
             transform_loc: get_uniform("transform"),
             tex_transform_loc: get_uniform("texTransform"),
             alpha_loc: get_uniform("alpha"),
+            matrix_loc: gl.get_attrib_location(&program, "matrix"),
             // Program has to be later than others
             program,
         }

--- a/src/shader_bundle.rs
+++ b/src/shader_bundle.rs
@@ -8,7 +8,7 @@ pub struct ShaderBundle {
     pub transform_loc: Option<WebGlUniformLocation>,
     pub tex_transform_loc: Option<WebGlUniformLocation>,
     pub alpha_loc: Option<WebGlUniformLocation>,
-    pub matrix_loc: i32,
+    pub position_loc: i32,
 }
 
 impl ShaderBundle {
@@ -33,7 +33,7 @@ impl ShaderBundle {
             transform_loc: get_uniform("transform"),
             tex_transform_loc: get_uniform("texTransform"),
             alpha_loc: get_uniform("alpha"),
-            matrix_loc: gl.get_attrib_location(&program, "matrix"),
+            position_loc: gl.get_attrib_location(&program, "position"),
             // Program has to be later than others
             program,
         }

--- a/src/shader_bundle.rs
+++ b/src/shader_bundle.rs
@@ -1,0 +1,39 @@
+use web_sys::{WebGlProgram, WebGlRenderingContext as GL, WebGlShader, WebGlUniformLocation};
+
+pub struct ShaderBundle {
+    pub program: WebGlProgram,
+    pub vertex_position: u32,
+    pub tex_coord_position: u32,
+    pub texture_loc: Option<WebGlUniformLocation>,
+    pub transform_loc: Option<WebGlUniformLocation>,
+    pub tex_transform_loc: Option<WebGlUniformLocation>,
+    pub alpha_loc: Option<WebGlUniformLocation>,
+}
+
+impl ShaderBundle {
+    pub fn new(gl: &GL, program: WebGlProgram) -> Self {
+        let get_uniform = |location: &str| {
+            let op: Option<WebGlUniformLocation> = gl.get_uniform_location(&program, location);
+            if op.is_none() {
+                console_log!("Warning: location {} undefined", location);
+            } else {
+                console_log!("location {} defined", location);
+            }
+            op
+        };
+        let vertex_position = gl.get_attrib_location(&program, "vertexData") as u32;
+        let tex_coord_position = gl.get_attrib_location(&program, "vertexData") as u32;
+        console_log!("vertex_position: {}", vertex_position);
+        console_log!("tex_coord_position: {}", tex_coord_position);
+        Self {
+            vertex_position,
+            tex_coord_position,
+            texture_loc: get_uniform("texture"),
+            transform_loc: get_uniform("transform"),
+            tex_transform_loc: get_uniform("texTransform"),
+            alpha_loc: get_uniform("alpha"),
+            // Program has to be later than others
+            program,
+        }
+    }
+}

--- a/src/shader_bundle.rs
+++ b/src/shader_bundle.rs
@@ -1,4 +1,4 @@
-use web_sys::{WebGlProgram, WebGlRenderingContext as GL, WebGlShader, WebGlUniformLocation};
+use web_sys::{WebGlProgram, WebGlRenderingContext as GL, WebGlUniformLocation};
 
 pub struct ShaderBundle {
     pub program: WebGlProgram,

--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
   </head>
 
   <body>
-      <canvas id="canvas" width="200" height="200" > </canvas>
+      <canvas id="canvas" width="400" height="400" > </canvas>
       <div>
         <label><input type="checkbox" id="animate" checked>Animate</label>
         <button id="buttonResetParticles">Reset particles</button>

--- a/static/index.html
+++ b/static/index.html
@@ -23,9 +23,10 @@
   </head>
 
   <body>
-      <canvas id="canvas" width="800" height="800" > </canvas>
+      <div id="canvasContainer"> </div>
       <div>
         <label><input type="checkbox" id="animate" checked>Animate</label>
+        <label><input type="checkbox" id="useWebGL">useWebGL</label>
         <button id="buttonResetParticles">Reset particles</button>
       </div>
       <div>Move your mouse cursor on the canvas to see the effect</div>

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
       <div id="canvasContainer"> </div>
       <div>
         <label><input type="checkbox" id="animate" checked>Animate</label>
-        <label><input type="checkbox" id="useWebGL">useWebGL</label>
+        <label><input type="checkbox" id="useWebGL" checked>Use WebGL</label>
         <button id="buttonResetParticles">Reset particles</button>
       </div>
       <div>Move your mouse cursor on the canvas to see the effect</div>

--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
   </head>
 
   <body>
-      <canvas id="canvas" width="400" height="400" > </canvas>
+      <canvas id="canvas" width="800" height="800" > </canvas>
       <div>
         <label><input type="checkbox" id="animate" checked>Animate</label>
         <button id="buttonResetParticles">Reset particles</button>


### PR DESCRIPTION
Canvas is inherently limited with `putImageData` in that pixel scale is fixed to 1 between image and canvas. Simulating fluid in high resolution in real time is very difficult (of course you could hack GLSL to do the simulation on GPU, but that's not our goal), so the canvas has to be low resolution and particles graphics are bound to that precision. With WebGL we can precisely control the resolution of the canvas and also the texture.

Canvas
![image](https://user-images.githubusercontent.com/2798715/116810040-6abd0900-ab7c-11eb-874d-2690bd6df086.png)

WebGL
![image](https://user-images.githubusercontent.com/2798715/116810045-714b8080-ab7c-11eb-8362-b42dcfa489f8.png)
